### PR TITLE
Добавляет сборку мульти-архитектурных образов docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Extract metadata and add tag with branch name
         id: meta
         uses: docker/metadata-action@v5
@@ -77,3 +85,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
В GitHub Actions обновлён пайплайн для сборки и публикации мульти-архитектурных образов Gateway.

- включён QEMU для эмуляции архитектур
- добавлен Buildx builder
- сборка контейнера переведена на multi-platform режим
- Docker-образы теперь публикуются для amd64 и arm64