### PR TITLE
feat: добавление заголовка X-Telegram-Username при проксировании запросов

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/gateway/filter/JwtClaimsToHeaderFilter.java
+++ b/src/main/java/com/itmentorcommunityplatform/gateway/filter/JwtClaimsToHeaderFilter.java
@@ -14,18 +14,24 @@ public class JwtClaimsToHeaderFilter implements Function<ServerRequest, ServerRe
 
     private static final String USER_ID_HEADER_NAME = "X-Telegram-User-Id";
     private static final String USER_ROLES_HEADER_NAME = "X-User-Roles";
+    private static final String USERNAME_HEADER_NAME = "X-Telegram-Username";
     private static final String ROLES_CLAIM_NAME = "roles";
+    private static final String USERNAME_CLAIM_NAME = "telegram_username";
 
     @Override
     public ServerRequest apply(ServerRequest request) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth instanceof JwtAuthenticationToken jwtAuth) {
             Jwt jwt = jwtAuth.getToken();
-            return ServerRequest.from(request)
+            ServerRequest.Builder builder = ServerRequest.from(request)
                     .header(USER_ID_HEADER_NAME, jwt.getSubject())
                     .header(USER_ROLES_HEADER_NAME,
-                            String.join(",", jwt.getClaimAsStringList(ROLES_CLAIM_NAME)))
-                    .build();
+                            String.join(",", jwt.getClaimAsStringList(ROLES_CLAIM_NAME)));
+            String telegramUsername = jwt.getClaimAsString(USERNAME_CLAIM_NAME);
+            if (telegramUsername != null) {
+                builder.header(USERNAME_HEADER_NAME, telegramUsername);
+            }
+            return builder.build();
         }
         return request;
     }

--- a/src/main/resources/application-ide.yaml
+++ b/src/main/resources/application-ide.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8085
+  port: 8080
 
 app:
   routes:

--- a/src/test/java/com/itmentorcommunityplatform/gateway/routes/GatewayGeneralIntegrationTest.java
+++ b/src/test/java/com/itmentorcommunityplatform/gateway/routes/GatewayGeneralIntegrationTest.java
@@ -40,8 +40,11 @@ public class GatewayGeneralIntegrationTest {
     private static final String ACCESS_TOKEN_HEADER_NAME = "X-Access-Token";
     private static final String USER_ID_HEADER_NAME = "X-Telegram-User-Id";
     private static final String USER_ROLES_HEADER_NAME = "X-User-Roles";
+    private static final String USERNAME_HEADER_NAME = "X-Telegram-Username";
     private static final String ROLES_CLAIM_NAME = "roles";
+    private static final String USERNAME_CLAIM_NAME = "telegram_username";
     private static final String TEST_USER = "user_telegram_id";
+    private static final String TEST_USERNAME = "zhukovsd";
     private static final String ROLE_ADMIN = "ADMIN";
     private static final String ROLE_STUDENT = "STUDENT";
     private final String jwtSecret;
@@ -57,7 +60,7 @@ public class GatewayGeneralIntegrationTest {
 
     public GatewayGeneralIntegrationTest(@Value("${jwt.secret}") String jwtSecret) {
         this.jwtSecret = jwtSecret;
-        this.validJwtTestUserAdminStudent = createValidJwt(TEST_USER, List.of(ROLE_ADMIN, ROLE_STUDENT));
+        this.validJwtTestUserAdminStudent = createValidJwt(TEST_USER, TEST_USERNAME, List.of(ROLE_ADMIN, ROLE_STUDENT));
     }
 
     @DynamicPropertySource
@@ -127,6 +130,7 @@ public class GatewayGeneralIntegrationTest {
                 getRequestedFor(urlEqualTo(TEST_SERVICE_PATH))
                         .withHeader(USER_ID_HEADER_NAME, equalTo(TEST_USER))
                         .withHeader(USER_ROLES_HEADER_NAME, equalTo(ROLE_ADMIN + "," + ROLE_STUDENT))
+                        .withHeader(USERNAME_HEADER_NAME, equalTo(TEST_USERNAME))
         );
     }
 
@@ -185,12 +189,13 @@ public class GatewayGeneralIntegrationTest {
         );
     }
 
-    private String createValidJwt(String userId, List<String> roles) {
+    private String createValidJwt(String userId, String username, List<String> roles) {
         SecretKey key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(jwtSecret));
         Date now = new Date();
         return Jwts.builder()
                 .subject(userId)
                 .claim(ROLES_CLAIM_NAME, roles)
+                .claim(USERNAME_CLAIM_NAME, username)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + 3_600_000L)) // 1 hour
                 .signWith(key)

--- a/src/test/java/com/itmentorcommunityplatform/gateway/security/jwt/HmacJjwtDecoderTest.java
+++ b/src/test/java/com/itmentorcommunityplatform/gateway/security/jwt/HmacJjwtDecoderTest.java
@@ -105,6 +105,7 @@ class HmacJjwtDecoderTest {
         return Jwts.builder()
                 .subject(subject)
                 .claim("roles", roles)
+                .claim("telegram_username", "test_username")
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plus(1, ChronoUnit.HOURS)))
                 .signWith(Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret)))


### PR DESCRIPTION

- В JwtClaimsToHeaderFilter добавлен Telegram username в заголовок X-Telegram-Username
- Заголовок передается из claims JWT (telegram_username) в проксируемые запросы
- Добавлены тесты для проверки передачи нового заголовка