### PR TITLE
fix: remove similar custom headers and set jwt-appropriate

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/gateway/filter/JwtClaimsToHeaderFilter.java
+++ b/src/main/java/com/itmentorcommunityplatform/gateway/filter/JwtClaimsToHeaderFilter.java
@@ -7,6 +7,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.function.ServerRequest;
 
+import java.util.List;
 import java.util.function.Function;
 
 @Component
@@ -21,19 +22,30 @@ public class JwtClaimsToHeaderFilter implements Function<ServerRequest, ServerRe
     @Override
     public ServerRequest apply(ServerRequest request) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
         if (auth instanceof JwtAuthenticationToken jwtAuth) {
             Jwt jwt = jwtAuth.getToken();
-            ServerRequest.Builder builder = ServerRequest.from(request)
-                    .header(USER_ID_HEADER_NAME, jwt.getSubject())
-                    .header(USER_ROLES_HEADER_NAME,
-                            String.join(",", jwt.getClaimAsStringList(ROLES_CLAIM_NAME)));
-            String telegramUsername = jwt.getClaimAsString(USERNAME_CLAIM_NAME);
-            if (telegramUsername != null) {
-                builder.header(USERNAME_HEADER_NAME, telegramUsername);
-            }
-            return builder.build();
+
+            return ServerRequest.from(request)
+                    .headers(headers -> {
+                        headers.remove(USER_ID_HEADER_NAME);
+                        headers.remove(USER_ROLES_HEADER_NAME);
+                        headers.remove(USERNAME_HEADER_NAME);
+
+                        headers.set(USER_ID_HEADER_NAME, jwt.getSubject());
+
+                        String telegramUsername = jwt.getClaimAsString(USERNAME_CLAIM_NAME);
+                        if (telegramUsername != null) {
+                            headers.set(USERNAME_HEADER_NAME, telegramUsername);
+                        }
+
+                        List<String> roles = jwt.getClaimAsStringList(ROLES_CLAIM_NAME);
+                        if (roles != null && !roles.isEmpty()) {
+                            headers.set(USER_ROLES_HEADER_NAME, String.join(",", roles));
+                        }
+                    })
+                    .build();
         }
         return request;
     }
 }
-


### PR DESCRIPTION
## Что сделано  
- заменил способ установки заголовков в ServerRequest - теперь, перед установкой заголовков из jwt - они предварительно очищаются, во избежание потенциальной подмены
- сделал ручные тесты к сервисам из gateway, которые требуют заголовки пользователя