### PR TITLE
feat: Добавил роутинг для telegram-bot-adapter

### DIFF
--- a/src/main/java/com/itmentorcommunityplatform/gateway/routes/GlobalGatewayRouterConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/gateway/routes/GlobalGatewayRouterConfig.java
@@ -29,9 +29,12 @@ public class GlobalGatewayRouterConfig {
                 HandlerFilterFunction.ofRequestProcessor(jwtClaimsFilter);
 
         return RouterFunctions.route()
-                .nest(request -> true, builder -> builder
+                .nest(request -> !request.path().startsWith("/api/telegram-bot-adapter"), builder -> builder
                         .add(defaultRouter)
                         .filter(filter)
+                )
+                .nest(request -> request.path().startsWith("/api/telegram-bot-adapter"),
+                        builder -> builder.add(defaultRouter)
                 )
                 .build();
     }

--- a/src/main/java/com/itmentorcommunityplatform/gateway/security/config/SecurityConfig.java
+++ b/src/main/java/com/itmentorcommunityplatform/gateway/security/config/SecurityConfig.java
@@ -53,6 +53,21 @@ public class SecurityConfig {
 
     @Bean
     @Order(2)
+    public SecurityFilterChain telegramBotAdapterSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/api/telegram-bot-adapter/**")
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(Customizer.withDefaults())
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+
+    @Bean
+    @Order(3)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
@@ -85,6 +100,8 @@ public class SecurityConfig {
     @Bean
     public InMemoryUserDetailsManager inMemoryUserDetailsManager(
             @Value("${monitoring.prometheus.password}") String rawPassword,
+            @Value("${telegram-bot-adapter.auth.username}") String adapterUsername,
+            @Value("${telegram-bot-adapter.auth.password}") String adapterPassword,
             PasswordEncoder passwordEncoder) {
 
         UserDetails prometheus = User.withUsername("prometheus")
@@ -92,7 +109,12 @@ public class SecurityConfig {
                 .roles("PROMETHEUS")
                 .build();
 
-        return new InMemoryUserDetailsManager(prometheus);
+        UserDetails telegramAdapter = User.withUsername(adapterUsername)
+                .password(passwordEncoder.encode(adapterPassword))
+                .roles("TELEGRAM_ADAPTER")
+                .build();
+
+        return new InMemoryUserDetailsManager(prometheus, telegramAdapter);
     }
 
     @Bean

--- a/src/main/resources/application-ide.yaml
+++ b/src/main/resources/application-ide.yaml
@@ -15,6 +15,8 @@ app:
       uri: http://localhost:8085
     job-market-analytics-service:
       uri: http://localhost:8086
+    telegram-bot-adapter:
+      uri: http://localhost:8087
 
 monitoring:
   prometheus:

--- a/src/main/resources/application-ide.yaml
+++ b/src/main/resources/application-ide.yaml
@@ -22,3 +22,8 @@ monitoring:
 
 jwt:
   secret: 632eca39fc29068edc74133ca9cf8f40b4942191f80c0c78dd588835beb5f57b
+
+telegram-bot-adapter:
+  auth:
+    username: username
+    password: password

--- a/src/main/resources/application-local-stack.yaml
+++ b/src/main/resources/application-local-stack.yaml
@@ -12,6 +12,8 @@ app:
       uri: http://mentor-service:8080
     job-market-analytics-service:
       uri: http://job-market-analytics-service:8080
+    telegram-bot-adapter:
+      uri: http://telegram-bot-adapter:8087
 
 monitoring:
   prometheus:

--- a/src/main/resources/application-local-stack.yaml
+++ b/src/main/resources/application-local-stack.yaml
@@ -19,3 +19,8 @@ monitoring:
 
 jwt:
   secret: 632eca39fc29068edc74133ca9cf8f40b4942191f80c0c78dd588835beb5f57b
+
+telegram-bot-adapter:
+  auth:
+    username: username
+    password: password

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -12,6 +12,8 @@ app:
       uri: ${MENTOR_SERVICE_URL:http://mentor-service:8080}
     job-market-analytics-service:
       uri: ${JOB_MARKET_ANALYTICS_SERVICE_URL:http://job-market-analytics-service:8080}
+    telegram-bot-adapter:
+      uri: ${TELEGRAM_BOT_ADAPTER_URL:http://telegram-bot-adapter:8080}
 
 monitoring:
   prometheus:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -20,4 +20,7 @@ monitoring:
 jwt:
   secret: ${JWT_SECRET}
 
-
+telegram-bot-adapter:
+  auth:
+    username: ${TELEGRAM_ADAPTER_USERNAME}
+    password: ${TELEGRAM_ADAPTER_PASSWORD}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,7 +31,7 @@ spring:
               predicates:
                 - Path=/api/job-market-analytics/**
             - id: telegram-bot-adapter
-              uri: ${app.routes.job-market-analytics-service.uri}
+              uri: ${app.routes.telegram-bot-adapter.uri}
               predicates:
                 - Path=/api/telegram-bot-adapter/**
 
@@ -52,6 +52,8 @@ app:
       uri: ${MENTOR_SERVICE_URI}
     job-market-analytics-service:
       uri: ${JOB_MARKET_ANALYTICS_SERVICE_URI}
+    telegram-bot-adapter:
+      uri: ${TELEGRAM_BOT_ADAPTER_URI}
 
 
 management:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,6 +30,10 @@ spring:
               uri: ${app.routes.job-market-analytics-service.uri}
               predicates:
                 - Path=/api/job-market-analytics/**
+            - id: telegram-bot-adapter
+              uri: ${app.routes.job-market-analytics-service.uri}
+              predicates:
+                - Path=/api/telegram-bot-adapter/**
 
 app:
   http-client:
@@ -67,3 +71,8 @@ monitoring:
 
 jwt:
   secret: ${JWT_SECRET}
+
+telegram-bot-adapter:
+  auth:
+    username: ${TELEGRAM_ADAPTER_USERNAME}
+    password: ${TELEGRAM_ADAPTER_PASSWORD}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -33,3 +33,8 @@ monitoring:
 
 jwt:
   secret: defaultSecretKeyThatIsLongLongLongEnoughForTests100500
+
+telegram-bot-adapter:
+  auth:
+    username: username
+    password: password


### PR DESCRIPTION
- настроил авторизацию через basic auth с стандартными кредами для профиля ide и local-stack
- Настроил маршрутизацию на Job Market Analytics Service который дает ответ о несуществовании хендлера для telegram-bot-adapter